### PR TITLE
Hotfix: Only purge utilities classes

### DIFF
--- a/template/postcss.config.js
+++ b/template/postcss.config.js
@@ -6,6 +6,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
     './src/**/*.jsx',
     './src/**/*.ts',
     './src/**/*.tsx',
+    './public/index.html',
   ],
 
   // Include any special characters you're using in this regular expression

--- a/template/src/index.css
+++ b/template/src/index.css
@@ -1,5 +1,7 @@
+/* purgecss start ignore */
 @tailwind base;
 
 @tailwind components;
+/* purgecss end ignore */
 
 @tailwind utilities;


### PR DESCRIPTION
This PR fixes an issue where base styles could be purged by mistake. We only want to purge unused utilities classes.