### PR TITLE
Move purgecss to dependency list

### DIFF
--- a/template.json
+++ b/template.json
@@ -5,9 +5,7 @@
     "tailwindcss": "^1.1.1",
     "@testing-library/react": "^9.3.2",
     "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/user-event": "^7.1.2"
-  },
-  "devdependencies": {
+    "@testing-library/user-event": "^7.1.2",
     "@fullhuman/postcss-purgecss": "^2.0.6"
   },
   "scripts": {


### PR DESCRIPTION
CRA templates do not support dev dependencies yet so they have to be added as a normal dependency.